### PR TITLE
Ensure that foreign key constraints are enforced

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ PRAGMA synchronous = NORMAL;
 PRAGMA page_size = 32768;
 PRAGMA cache_size = -20000;
 PRAGMA auto_vacuum = incremental;
+PRAGMA foreign_keys = ON;
 // etc...
 ```
 

--- a/database/migrations/optimize_database_settings.php.stub
+++ b/database/migrations/optimize_database_settings.php.stub
@@ -17,6 +17,7 @@ return new class extends Migration
             DB::statement('PRAGMA page_size = 32768;');
             DB::statement('PRAGMA cache_size = -20000;');
             DB::statement('PRAGMA auto_vacuum = incremental;');
+            DB::statement('PRAGMA foreign_keys = ON;');
         }
     }
 };


### PR DESCRIPTION
This change improves the migration stub by adding the PRAGMA statement for `foreign_keys ` to ensure that foreign key constraints are enforced.